### PR TITLE
Added field trip node edges

### DIFF
--- a/src/components/TabViewer/model.js
+++ b/src/components/TabViewer/model.js
@@ -119,7 +119,8 @@ export function getFieldtripsByID(fieldtrip_id) {
     // if anything but the all fieldtrip is selected
     if (fieldtrip_id !== allFieldtripId) {
         // retrieve the relevant information
-        var fieldtripObject = fieldtripsData[fieldtrip_id];
+        // IMPORTANT: use spread syntax so that we don't mutate the original fieldtrip data
+        var fieldtripObject = {...fieldtripsData[fieldtrip_id]};
         // if people_visited exists in fieldtripObject
         if ("people_visited" in fieldtripObject) {
             // ensure that people_visited is an array

--- a/src/components/UserNexus/UserNexusModel.js
+++ b/src/components/UserNexus/UserNexusModel.js
@@ -1,5 +1,10 @@
 // functions to get people, places, stories
-import {getStoryByID, getPeopleByID, getPlacesByID} from "../TabViewer/model";
+import {
+    getFieldtripsByID,
+    getPeopleByID,
+    getPlacesByID,
+    getStoryByID,
+} from "../TabViewer/model";
 // function to ensure an input is an array
 import {arrayTransformation} from "../../utils";
 
@@ -177,6 +182,17 @@ export function createLinkage({id, itemID, type}, nodeCategories) {
                 // extract mentioned stories, ensure that it is an array, and get their IDs
                 ...arrayTransformation(storiesMentioned).map(story => story["story_id"]),
             ];
+            break;
+        }
+        case "Fieldtrips": {
+            // get the people and places visited as well as the collected stories
+            const {people_visited, places_visited, stories_collected} = getFieldtripsByID(itemID);
+
+            // get the people, places visited + stories collected, ensure that each is an array, and get their IDs
+            currItemPeople = arrayTransformation(people_visited).map(person => person["person_id"]);
+            currItemPlaces = arrayTransformation(places_visited).map(place => place["place_id"]);
+            currItemStories = arrayTransformation(stories_collected).map(story => story["story_id"]);
+
             break;
         }
         default:


### PR DESCRIPTION
Close #59

Note that this only adds edges if the fieldtrip is visited AFTER the people/places/stories are added to the graph. Reclicking the fieldtrip from the main view, but not the bottom bar, will correctly update its links.

Similar to the edges for people and places, copy-paste to extract the needed people, places, and stories. Had to use spread syntax in getFieldtripsByID (components/TabViewer/model.js: 122) so that the function doesn't mutate the original fieldtrip data.