### PR TITLE
Double click on a graph node takes you to the node's page

### DIFF
--- a/src/components/Navigation/Navigation.js
+++ b/src/components/Navigation/Navigation.js
@@ -10,7 +10,7 @@ import "./navigation.css";
 // the nexus graph
 import NexusGraph from "../NexusGraph/NexusGraph";
 // functions to get nodes + links
-import {addNode, initializeGraph} from "../NexusGraph/NexusGraphModel";
+import {addNode, initializeGraph, initializeNodeCategories} from "../NexusGraph/NexusGraphModel";
 
 class Navigation extends Component {
     constructor() {
@@ -363,10 +363,16 @@ class Navigation extends Component {
                             <div
                                 className="medium-6 cell">
                                 {/* button that creates + opens the graph tab when clicked (Navigation.js:handleDisplayGraph())*/}
-                                <button onClick={this.handleDisplayGraph}>Expand Nexus Graph</button>
+                                <button className="button primary" id="expandGraphButton" onClick={this.handleDisplayGraph}>Expand Nexus Graph</button>
                                 {/* the nexus graph */}
                                 <NexusGraph
+                                    // nodes + links for the graph to render
                                     data={initializeGraph()}
+                                    // function to open a node's page if clicked
+                                    openNode={this.props.addID}
+                                    // a totality of all the nodes, sorted by type
+                                    nodes={initializeNodeCategories()}
+                                    // custom settings for the graph
                                     settings={{
                                         // set the height to center the graph
                                         "height": (window.innerHeight) * 0.8 * .5,

--- a/src/components/Navigation/navigation.css
+++ b/src/components/Navigation/navigation.css
@@ -126,3 +126,9 @@
 .hintText {
     margin-left: 20px;
 }
+
+/* button that creates the nexus graph tab */
+#expandGraphButton {
+    /* don't add excess space around the button */
+    margin: 0;
+}

--- a/src/components/NexusGraph/GraphView.js
+++ b/src/components/NexusGraph/GraphView.js
@@ -3,9 +3,11 @@ import React, {Component} from "react";
 // styling for the buttons
 import "./GraphView.css";
 // functions to get nodes + links
-import {initializeGraph} from "./NexusGraphModel";
+import {initializeGraph, initializeNodeCategories} from "./NexusGraphModel";
 // the actual graph
 import NexusGraph from "./NexusGraph";
+// prop validation
+import PropTypes from "prop-types";
 
 class GraphView extends Component {
     constructor() {
@@ -14,6 +16,8 @@ class GraphView extends Component {
         this.state = {
             // this will be overridden by componentWillMount()
             "data": {},
+            // this will be overridden by componentWillMount()
+            "nodeCategories": {},
             // by default show primary links
             "showPrimaryLinks": true,
             // by default show secondary links
@@ -29,6 +33,7 @@ class GraphView extends Component {
         this.setState({
             // data = nodes + links from storage
             "data": initializeGraph(),
+            "nodeCategories": initializeNodeCategories(),
         });
     }
 
@@ -78,27 +83,41 @@ class GraphView extends Component {
         return (
             // div to contain both the button and graph
             <div>
+                {/* contains the filters */}
                 <form>
+                    {/* toggle primary links filter */}
                     <label>
+                        {/* give the text "Primary" a light blue color to indicate which links it matches to */}
                         Show <span className="lightblue">Primary</span> Links:
                         <input
-                            name="primaryLinks"
+                            // make it a checkbox
                             type="checkbox"
+                            // its state should be set by whether or not to show primary links
                             checked={this.state.showPrimaryLinks}
+                            // when this is changed (i.e. pressed) call the togglePrimaryLinks function
                             onChange={this.togglePrimaryLinks} />
                     </label>
                     <label>
+                        {/* give the text "Secondary" a light green color to indicate which links it matches to */}
                         Show <span className="lightgreen">Secondary</span> Links:
                         <input
-                            name="primaryLinks"
+                            // make it a checkbox
                             type="checkbox"
+                            // its state should be set by whether or not to show secondary links
                             checked={this.state.showSecondaryLinks}
+                            // when this is changed (i.e. pressed) call the toggleSecondaryLinks function
                             onChange={this.toggleSecondaryLinks} />
                     </label>
                 </form>
                 {/* the actual graph */}
                 <NexusGraph
+                    // nodes + links for the graph to render
                     data={finalData}
+                    // a totality of all the nodes, sorted by type
+                    nodes={this.state.nodeCategories}
+                    // function to open a node's page if clicked
+                    openNode={this.props.openNode}
+                    // custom settings for the graph
                     settings={{
                         // set the height to occupy most of the screen
                         "height": (window.innerHeight) * 0.8,
@@ -110,5 +129,9 @@ class GraphView extends Component {
         );
     }
 }
+
+GraphView.propTypes = {
+    "openNode": PropTypes.func.isRequired,
+};
 
 export default GraphView;

--- a/src/components/NexusGraph/NexusGraphModel.js
+++ b/src/components/NexusGraph/NexusGraphModel.js
@@ -199,6 +199,27 @@ function getPrimaryAssociates(itemID, type) {
 }
 
 /**
+ * Retrieve a node by its name
+ * @param {String} name The display name of the node
+ * @param {Object} nodeCategories The nodes to search through (should be all nodes on the graph)
+ * @returns {Node} A node that matches the specified name, or null if no match was found
+ */
+export function getNodeById(name, nodeCategories) {
+    // for each of the categories of nodes (people, places, fieldtrips, stories)
+    for (let nodeType in nodeCategories) {
+        // attempt to find a node whose name matches the passed name
+        let node = nodeCategories[nodeType].find(nodeToTest => nodeToTest["id"] === name);
+        // if we actually found such a node
+        if (typeof node !== "undefined") {
+            // return that node
+            return node;
+        }
+    }
+    // if we couldn't find a match, return null
+    return null;
+}
+
+/**
  * Create linkages for a node
  * @param {Node} node The node to create linkages for
  * @param {Array} nodeCategories An array of nodes to use to find linkages
@@ -274,7 +295,10 @@ export function createLinkage({id, itemID, type}, nodeCategories) {
                 // if any secondary associated nodes that are already on the graph
                 diff(secondaryAssociates[nodeType], pastNodes[nodeType])
                     // convert each of the numeric IDs to the node's name
-                    .map(matchID => nodeCategories[nodeType].find(node => node["itemID"] === matchID)["id"])
+                    .map(matchID => {
+                        console.log(matchID);
+                        return nodeCategories[nodeType].find(node => node["itemID"] === matchID)["id"];
+                    })
                     // filter out links that point right back to the current node
                     .filter(matchID => matchID !== id)
                     // and, for each of the remaining secondarily associated nodes' links

--- a/src/components/TabViewer/TabViewer.js
+++ b/src/components/TabViewer/TabViewer.js
@@ -131,8 +131,8 @@ class TabViewer extends Component {
                 // for the Home tab, return the main Navigation view (home), with addTab for any selected tabs
                 return <Navigation addID={this.addTab} />;
             case "Graph":
-                // for the graph, return the GraphView
-                return <GraphView />;
+                // for the graph, return the GraphView, with addTab to open pages on double clicked nodes
+                return <GraphView openNode={this.addTab} />;
             default:
                 // if it wasn't one of the above types, warn that we hit an unknown type
                 console.warn(`Unhandled tab type ${type}`);


### PR DESCRIPTION
Close #67

Since there are no double click event handlers, I had to implement my own based on the single click handler to check if the same node was clicked twice consecutively within 1 second. If so, call the addTab function in TabViewer.js to open its page based on the node retrieved from NexusGraphModel.js:getNodeById

Also added the classes "button primary" to the expand graph button and made it fit nicely into Navigation