### PR TITLE
Formatted expand graph button + filters

### DIFF
--- a/src/components/Navigation/Navigation.js
+++ b/src/components/Navigation/Navigation.js
@@ -363,7 +363,15 @@ class Navigation extends Component {
                             <div
                                 className="medium-6 cell">
                                 {/* button that creates + opens the graph tab when clicked (Navigation.js:handleDisplayGraph())*/}
-                                <button className="button primary" id="expandGraphButton" onClick={this.handleDisplayGraph}>Expand Nexus Graph</button>
+                                <button
+                                    // CSS classes
+                                    className="button primary"
+                                    // CSS id
+                                    id="expandGraphButton"
+                                    // when clicked, open the graph in its own tab
+                                    onClick={this.handleDisplayGraph}>
+                                    Open Graph in New Tab
+                                </button>
                                 {/* the nexus graph */}
                                 <NexusGraph
                                     // nodes + links for the graph to render

--- a/src/components/Navigation/navigation.css
+++ b/src/components/Navigation/navigation.css
@@ -131,4 +131,8 @@
 #expandGraphButton {
     /* don't add excess space around the button */
     margin: 0;
+    /* expand it to occupy the whole width of its space */
+    width: 100%;
+    /* remove excess padding */
+    padding: 5px 0;
 }

--- a/src/components/NexusGraph/GraphView.css
+++ b/src/components/NexusGraph/GraphView.css
@@ -1,13 +1,29 @@
-label {
-    margin-left: 10px;
-    margin-top: 5px;
-    display: inline;
-}
-
+/* for any text that needs to be light green */
 .lightgreen {
+    /* light green text color */
     color: lightgreen;
 }
 
+/* for any text that needs to be light blue */
 .lightblue {
+    /* light blue text color */
     color: lightblue;
+}
+
+/* styling for the filter portion */
+#analysisTools {
+    /* a really light gray background to slightly differentiate it from the graph */
+    background-color: #fafafa;
+}
+
+/* styling for each individual filter */
+.tool {
+    /* space it a little from the left edge */
+    margin-left: 5px;
+}
+
+/* styling for the Analysis Tools header */
+#heading {
+    /* center the text */
+    text-align: center;
 }

--- a/src/components/NexusGraph/GraphView.js
+++ b/src/components/NexusGraph/GraphView.js
@@ -82,13 +82,12 @@ class GraphView extends Component {
         }
         return (
             // div to contain both the button and graph
-            <div>
+            <div className="grid-x">
                 {/* contains the filters */}
-                <form>
+                <form className="medium-3 cell grid-y" id="analysisTools">
+                    <h3 className="cell" id="heading">Analysis Tools</h3>
                     {/* toggle primary links filter */}
-                    <label>
-                        {/* give the text "Primary" a light blue color to indicate which links it matches to */}
-                        Show <span className="lightblue">Primary</span> Links:
+                    <label className="cell tool">
                         <input
                             // make it a checkbox
                             type="checkbox"
@@ -96,10 +95,10 @@ class GraphView extends Component {
                             checked={this.state.showPrimaryLinks}
                             // when this is changed (i.e. pressed) call the togglePrimaryLinks function
                             onChange={this.togglePrimaryLinks} />
+                        {/* give the text "Primary" a light blue color to indicate which links it matches to */}
+                        Show <span className="lightblue">Primary</span> Links
                     </label>
-                    <label>
-                        {/* give the text "Secondary" a light green color to indicate which links it matches to */}
-                        Show <span className="lightgreen">Secondary</span> Links:
+                    <label className="cell tool">
                         <input
                             // make it a checkbox
                             type="checkbox"
@@ -107,24 +106,30 @@ class GraphView extends Component {
                             checked={this.state.showSecondaryLinks}
                             // when this is changed (i.e. pressed) call the toggleSecondaryLinks function
                             onChange={this.toggleSecondaryLinks} />
+                        {/* give the text "Secondary" a light green color to indicate which links it matches to */}
+                        Show <span className="lightgreen">Secondary</span> Links
                     </label>
                 </form>
                 {/* the actual graph */}
-                <NexusGraph
-                    // nodes + links for the graph to render
-                    data={finalData}
-                    // a totality of all the nodes, sorted by type
-                    nodes={this.state.nodeCategories}
-                    // function to open a node's page if clicked
-                    openNode={this.props.openNode}
-                    // custom settings for the graph
-                    settings={{
-                        // set the height to occupy most of the screen
-                        "height": (window.innerHeight) * 0.8,
-                        // set the width to occupy the whole width of the screen
-                        "width": window.innerWidth,
-                    }}
-                />
+                <div>
+                    <NexusGraph
+                        // give it 3/4 of the screen width
+                        className="medium-9 cell"
+                        // nodes + links for the graph to render
+                        data={finalData}
+                        // a totality of all the nodes, sorted by type
+                        nodes={this.state.nodeCategories}
+                        // function to open a node's page if clicked
+                        openNode={this.props.openNode}
+                        // custom settings for the graph
+                        settings={{
+                            // set the height to occupy most of the screen
+                            "height": (window.innerHeight) * 0.8,
+                            // set the width to be just under 3/4 the screen width (so it doesn't overflow into a new row)
+                            "width": window.innerWidth * 0.74,
+                        }}
+                    />
+                </div>
             </div>
         );
     }


### PR DESCRIPTION
Close #122

Just some CSS and tweaking the JSX so that the elements get the right classes. Expand Graph button now occupies its whole width (no blank space around it). Graph tab now has the filters on the left, similar to how Navigation is structured.