### PR TITLE
Clicking on the open book closes the book chpater selection dropdown

### DIFF
--- a/src/components/Heading/Heading.js
+++ b/src/components/Heading/Heading.js
@@ -66,7 +66,7 @@ class Heading extends Component {
                     <div className="solid">
                         {/* little open book at the top right */}
                         <div className="Hamburger-Menu" onClick={this.menuToggle}>
-                            <img src="https://png.icons8.com/wired/50/ffffff/literature.png" style={{"height": "2.9em", "paddingTop": "5px"}} alt="open book" />
+                            <img src="https://png.icons8.com/wired/50/ffffff/literature.png" style={{"height": "2.9em", "paddingTop": "5px"}} alt="open book" onClick={this.menuToggle} />
                         </div>
                         {/* list of all the chapters */}
                         <ul className="list">


### PR DESCRIPTION
Close #132

I really wasn't expecting it to be that easy, just had to add a third this.menuToggle so that we maintain the click-away-to-hide functionality but because three toggles is equivalent to one toggle, clicking the image now closes the bar as well.