### PR TITLE
Tab that is being dragged turns gray

### DIFF
--- a/src/actions/actionTypes.js
+++ b/src/actions/actionTypes.js
@@ -3,3 +3,4 @@ export const ADD_TAB = "ADD_TAB";
 export const CLOSE_TAB = "CLOSE_TAB";
 export const INITIALIZE_TABS = "INITIALIZE_TABS";
 export const MOVE_TAB = "MOVE_TAB";
+export const CHANGE_TAB_COLOR = "CHANGE_TAB_COLOR";

--- a/src/actions/tabViewerActions.js
+++ b/src/actions/tabViewerActions.js
@@ -1,38 +1,60 @@
 import * as types from "./actionTypes";
 
 /**
- * triggers reducer for adding a tab
- * @param {integer} DisplayArtifactID
- * @param {string} name
- * @param {string} type
- * */
+ * Add a tab to the view
+ * @param {Number} DisplayArtifactID ID referring to the item to display
+ * @param {String} name Display name of the tab
+ * @param {String} type Type of the display
+ */
 export function addTab(DisplayArtifactID, name, type) {
-    const TabPayload = {DisplayArtifactID, name, type};
-    return {"type": types.ADD_TAB, "payload": TabPayload};
+    return {
+        "type": types.ADD_TAB,
+        "payload": {DisplayArtifactID, name, type},
+    };
 }
 
 /**
- * triggers reducer for closing a tab
- * @param {integer} TabKey to delete
- * */
+ * Close a tab
+ * @param {Number} TabKey Index of the tab to close
+ */
 export function closeTab(TabKey) {
-    return {"type": types.CLOSE_TAB, "payload": TabKey};
+    return {
+        "type": types.CLOSE_TAB,
+        "payload": TabKey,
+    };
 }
 
 /**
- * triggers reducer for switch a tab
- * @param {integer} TabKey to switch to
- * */
+ * Switch to the specified tab
+ * @param {Number} TabKey Index of the tab to switch to
+ */
 export function switchTabs(TabKey) {
-    return {"type": types.SWITCH_TABS, "payload": TabKey};
+    return {
+        "type": types.SWITCH_TABS,
+        "payload": TabKey,
+    };
 }
 
 /**
- * triggers reducer for moving a tab
+ * Move a tab to a new index
  * @param {Number} OldTabIndex The tab to move
  * @param {Number} NewTabIndex The spot to move the tab to
  */
 export function moveTab(OldTabIndex, NewTabIndex) {
-    const TabPayload = {OldTabIndex, NewTabIndex};
-    return {"type": types.MOVE_TAB, "payload": TabPayload};
+    return {
+        "type": types.MOVE_TAB,
+        "payload": {OldTabIndex, NewTabIndex},
+    };
+}
+
+/**
+ * Change a tab's color
+ * @param {Number} TabIndex The tab to colorize
+ * @param {*} Color The new color of the tab - `null` resets it to the active/inactive color
+ */
+export function changeTabColor(TabIndex, Color) {
+    return {
+        "type": types.CHANGE_TAB_COLOR,
+        "payload": {TabIndex, Color},
+    };
 }

--- a/src/reducers/initialState.js
+++ b/src/reducers/initialState.js
@@ -1,33 +1,35 @@
-import * as TabViewer from "../components/TabViewer/TabViewer";
+// function to get tab state from storage
 import {getSessionStorage} from "../data-stores/SessionStorageModel";
 
-const NavigationObject = {
-    "active": true,
-    "id": 0,
-    "name": "Home",
-    "type": "Home",
-};
-
-export default {
-    tabState:InitializeTabs(),
-};
-
-
-function InitializeTabs(){
+/**
+ * Initialize the tabs, whether from a clean state or session storage
+ * @returns {Object} The state of the tabs
+ */
+function InitializeTabs() {
+    // get tab state from storage
     const CachedState = getSessionStorage("TabViewerSessionState");
-    var NewState = {};
-    console.log(TabViewer, 'tab viewer');
-    if(CachedState){
-        const cachedViews = CachedState["views"];
-        NewState = {
-            views: cachedViews
-        }
-
-        // NewState['views']['jsx'] = TabViewer.
+    console.log(CachedState);
+    // if we have previously loaded tabs
+    if (CachedState) {
+        // start up with those previous tabs
+        return {
+            "views": CachedState.views,
+        };
     } else {
-        NewState = {
-            views:[NavigationObject]
-        }
+        // otherwise, just start out with a single home tab
+        return {
+            "views": [{
+                "active": true,
+                "id": 0,
+                "name": "Home",
+                "type": "Home",
+                "color": null,
+            }],
+        };
     }
-    return NewState;
 }
+
+// export the initialized state
+export default {
+    "tabState": InitializeTabs(),
+};

--- a/src/reducers/tabViewerReducer.js
+++ b/src/reducers/tabViewerReducer.js
@@ -85,6 +85,8 @@ function addTab(ShallowNewState, {DisplayArtifactID, name, type}) {
             "name": name,
             // type is the passed type
             "type": type,
+            // color is the default active/inactive color
+            "color": null,
         };
         // for each of the preexisting views
         let updatedViews = newState.views.map((view) => {
@@ -152,6 +154,21 @@ function moveTab(OldState, {OldTabIndex, NewTabIndex}) {
 }
 
 /**
+ * Change the color of a tab
+ * @param {*} OldState The pre-color change state
+ * @param {*} payload Contains TabIndex, to indicate the tab to change, and Color, which is either a string/hexcode, or null to fall back to default active/inactive colors
+ * @returns {Object} The color changed state
+ */
+function changeTabColor(OldState, {TabIndex, Color}) {
+    // get a new copy of the state to keep immutability
+    let newState = {...OldState};
+    // set the specified tab's color
+    newState.views[TabIndex].color = Color;
+    // return the state with the changed tab
+    return newState;
+}
+
+/**
  * Generic handler for manipulating the tabs and updating their state
  * @param {Object} state The pre-update state
  * @param {Object} action Action to do to the tabs (ADD_TAB, SWITCH_TABS, CLOSE_TAB)
@@ -172,10 +189,15 @@ export default function tabViewer(state = initialState.tabState, action) {
         case actions.CLOSE_TAB:
             console.log("CLOSE_TAB ACTION", state);
             return closeTab(state, action.payload);
+        // if we are to move around a tab
         case actions.MOVE_TAB:
             console.log("MOVE_TAB ACTION", state);
             return moveTab(state, action.payload);
-        // unhandled error type
+        // if we are to change a tab's color
+        case actions.CHANGE_TAB_COLOR:
+            console.log("CHANGE_TAB_COLOR ACTION", state);
+            return changeTabColor(state, action.payload);
+        // unhandled action type
         default:
             // warn that we hit a bad action
             console.warn(`Invalid action: ${action.type}`);


### PR DESCRIPTION
Just to make the dragging experience more interesting, I added a new function to change a tab's bakground color - setting the color to `null` lets it fall back onto the default active/inactive background color. Tab color is set to gray while being dragged, then reset to null once the drag is over. Also, the drag indicator does not show up if the tab would be dropped down into the same place - this helps to make the indicator feel more consistent.