### PR TITLE
Book tabs partially remember their last page when switched away from

### DIFF
--- a/src/actions/actionTypes.js
+++ b/src/actions/actionTypes.js
@@ -3,4 +3,4 @@ export const ADD_TAB = "ADD_TAB";
 export const CLOSE_TAB = "CLOSE_TAB";
 export const INITIALIZE_TABS = "INITIALIZE_TABS";
 export const MOVE_TAB = "MOVE_TAB";
-export const CHANGE_TAB_COLOR = "CHANGE_TAB_COLOR";
+export const UPDATE_TAB = "UPDATE_TAB";

--- a/src/actions/tabViewerActions.js
+++ b/src/actions/tabViewerActions.js
@@ -48,13 +48,13 @@ export function moveTab(OldTabIndex, NewTabIndex) {
 }
 
 /**
- * Change a tab's color
- * @param {Number} TabIndex The tab to colorize
- * @param {*} Color The new color of the tab - `null` resets it to the active/inactive color
+ * Update some of a tab's properties
+ * @param {Number} TabIndex The tab to update
+ * @param {*} updates The properties of the tab to update with their desired values
  */
-export function changeTabColor(TabIndex, Color) {
+export function updateTab(TabIndex, updates) {
     return {
-        "type": types.CHANGE_TAB_COLOR,
-        "payload": {TabIndex, Color},
+        "type": types.UPDATE_TAB,
+        "payload": {TabIndex, updates},
     };
 }

--- a/src/components/BookView/BookView.js
+++ b/src/components/BookView/BookView.js
@@ -5,57 +5,20 @@ import {ReactReader} from "react-reader";
 // prop validation
 import PropTypes from "prop-types";
 // chapter data
-import menuList from "../../data/book_menu.json";
 import "./BookView.css";
 
 class BookView extends Component {
-    constructor() {
-        super();
-        // initial state
+    constructor(props) {
+        super(props);
         this.state = {
-            // prop chapter
-            "id": 0,
-            // start on the first page
-            "location": 0,
             // start with normal text
             "largeText": false,
         };
         // to be set once the book is rendered
         this.rendition = null;
         // bind the functions so that they function properly in sub-elements
-        this.onLocationChanged = this.onLocationChanged.bind(this);
         this.onToggleFontSize = this.onToggleFontSize.bind(this);
         this.getRendition = this.getRendition.bind(this);
-    }
-
-    // called at the first loading of the component
-    componentDidMount() {
-        this.setState({
-            // set the chapter that we got loaded to
-            "propChapter": this.props.id,
-        });
-    }
-
-    // called whenever we get a chapter to go to (includes initial render)
-    static getDerivedStateFromProps(props, state) {
-        // if we actually got a prop update and not a state update (chapter changed)
-        if (props.id !== state.id) {
-            // update the state
-            return {
-                // update the chapter we go to
-                "id": props.id,
-                // go to the chapter that was selected
-                "location": menuList[props.id].location,
-            };
-        }
-    }
-
-    // called when the page changes
-    onLocationChanged(prevLocation) {
-        this.setState({
-            // update the page
-            "location": prevLocation,
-        });
     }
 
     // toggle between zoomed/unzoomed font
@@ -73,12 +36,10 @@ class BookView extends Component {
 
     // get a reference to the rendered book
     getRendition(rendition) {
-        // set inital font-size, and add a pointer to rendition for later updates
-        const {largeText} = this.state;
         // reference to the rendered book
         this.rendition = rendition;
         // enlarge the font if needed
-        rendition.themes.fontSize(largeText ? "140%" : "100%");
+        rendition.themes.fontSize(this.state.largeText ? "140%" : "100%");
     }
 
     render() {
@@ -89,10 +50,10 @@ class BookView extends Component {
                     // path to the .epub file
                     url={"/Book/merge_from_ofoct.epub"}
                     // page to load
-                    location={this.state.location}
+                    location={this.props.page}
                     // callback for when the page is changed
-                    locationChanged={this.onLocationChanged}
-                    // callback for when the book finishes rendering
+                    locationChanged={this.props.handleLocationChanged}
+                    // callback for when the book is rendered
                     getRendition={this.getRendition}
                 />
                 {/* button to zoom the font in/out */}
@@ -110,12 +71,10 @@ class BookView extends Component {
 }
 
 BookView.propTypes = {
-    // must have id to load a chapter
-    "id": PropTypes.number.isRequired,
-};
-
-BookView.defaultProps = {
-    "id": 0,
+    // callback for when we switch pages
+    "handleLocationChanged": PropTypes.func.isRequired,
+    // the page we are currently displaying
+    "page": PropTypes.number.isRequired,
 };
 
 export default BookView;

--- a/src/components/Heading/Heading.js
+++ b/src/components/Heading/Heading.js
@@ -95,7 +95,7 @@ class Heading extends Component {
                                         // prevent default click behavior
                                         event.preventDefault();
                                         // add a tab to the desired chapter
-                                        this.props.tabViewerActions.addTab(i, menuItem.name, "Book");
+                                        this.props.tabViewerActions.addTab(menuItem.location, menuItem.name, "Book");
                                     }}
                                 >{menuItem.name}</li>;
                             })}

--- a/src/components/MapView/MapView.js
+++ b/src/components/MapView/MapView.js
@@ -193,7 +193,7 @@ MapView.propTypes = {
     "person": PropTypes.array.isRequired,
     "places": PropTypes.array.isRequired,
     "stories": PropTypes.array.isRequired,
-    "height": PropTypes.number.isRequired,
+    "height": PropTypes.string,
 };
 
 // assign defaults if not already defined

--- a/src/components/NexusGraph/NexusGraph.js
+++ b/src/components/NexusGraph/NexusGraph.js
@@ -1,6 +1,6 @@
-// basic react functionality
 // styling for the graph
 import "./NexusGraph.css";
+// basic react functionality
 import React, {Component} from "react";
 // graph functionality for the NexusGraph
 import {Graph} from "react-d3-graph";
@@ -35,27 +35,21 @@ const settings = {
 };
 
 class NexusGraph extends Component {
-    constructor() {
-        super();
-        // set an initial state
-        this.state = {
-            // initially, no node clicked
-            "lastNodeClicked": null,
-            // since no node is initially clicked, don't set a real time
-            "lastNodeClickTime": 0,
-        };
-
+    constructor(props) {
+        super(props);
+        // no clicks handled yet
+        this.lastNodeClicked = null;
+        this.lastNodeClickTime = 0;
         // properly bind handleClickNode so it works on the nodes in the graph
         this.handleClickNode = this.handleClickNode.bind(this);
     }
 
+    // called whenever a node is clicked
     handleClickNode(nodeName) {
-        // condition to treat it as a double click
-
-        // if last click was within 1 second
-        if (Date.now() - this.state.lastNodeClickTime < 1000 &&
+        // condition to treat it as a double click, if last click was within 1 second
+        if (Date.now() - this.lastNodeClickTime < 1000 &&
             // and the same node was clicked both times,
-            nodeName === this.state.lastNodeClicked) {
+            nodeName === this.lastNodeClicked) {
             // get the node matching the given name
             let node = getNodeById(nodeName, this.props.nodes);
             // assuming we properly retrieved the node
@@ -64,13 +58,11 @@ class NexusGraph extends Component {
                 this.props.tabViewerActions.addTab(node.itemID, nodeName, node.type);
             }
         } else {
-            // too long between clicks or different nodes clicked, treat it as a single click
-            this.setState({
-                // update the latest click time to be now
-                "lastNodeClickTime": Date.now(),
-                // update the latest clicked node to be this node
-                "lastNodeClicked": nodeName,
-            });
+            // too long between clicks/different node clicked, it should be a single click
+            // set last click to be now
+            this.lastNodeClickTime = Date.now();
+            // the clicked node is now the one that was last clicked
+            this.lastNodeClicked = nodeName;
         }
     }
 
@@ -89,7 +81,7 @@ class NexusGraph extends Component {
                     ...this.props.settings,
                 }}
                 // call the custom callback when a node is clicked
-                onClickNode={this.handleClickNode}
+                onClickNode={this.handleClickNode.bind(this)}
             />
         );
     }
@@ -101,14 +93,8 @@ NexusGraph.propTypes = {
         "target": PropTypes.string.isRequired,
         "linkNode": PropTypes.any,
         "color": PropTypes.string,
-    })).isRequired,
-    "nodes": PropTypes.arrayOf(PropTypes.shape({
-        "id": PropTypes.string.isRequired,
-        "color": PropTypes.string,
-        "item": PropTypes.any,
-        "type": PropTypes.string,
-        "itemID": PropTypes.number,
-    })).isRequired,
+    })),
+    "nodes": PropTypes.object.isRequired,
     "data": PropTypes.object.isRequired,
     "settings": PropTypes.object,
     "tabViewerActions": PropTypes.object.isRequired,
@@ -116,8 +102,6 @@ NexusGraph.propTypes = {
 
 NexusGraph.defaultProps = {
     "nodes": [{"id": "blank"}],
-    "links": [],
-    "settings": {},
 };
 
 function mapStateToProps(state) {

--- a/src/components/PlaceView/PlaceView.js
+++ b/src/components/PlaceView/PlaceView.js
@@ -6,15 +6,6 @@ import PropTypes from "prop-types";
 import {arrayTransformation} from "../../utils";
 
 class PlaceView extends Component {
-    constructor() {
-        super();
-        this.clickHandler = this.clickHandler.bind(this);
-    }
-
-    clickHandler(id, name, type) {
-        this.props.addID(id, name, type);
-    }
-
     render() {
         const {place} = this.props;
         let {name, people, storiesCollected, storiesMentioned} = place;
@@ -28,14 +19,6 @@ class PlaceView extends Component {
         }
         storiesCollected = arrayTransformation(storiesCollected);
         storiesMentioned = arrayTransformation(storiesMentioned);
-        // // if storiesCollected is undefined, set it to an empty array
-        // if (typeof storiesCollected === "undefined") {
-        //     storiesCollected = [];
-        // }
-        // if storiesMentioned is undefined, set it to an empty array
-        // if (typeof storiesMentioned === "undefined") {
-        //     storiesMentioned = [];
-        // }
         return (
             <div className="PlaceView grid-y">
                 <div className="tab-header cell medium-1">
@@ -47,8 +30,7 @@ class PlaceView extends Component {
                         <div className="medium-11 cell">
                             <MapView places={[place]} />
                         </div>
-                        <RightBar view="Places" stories={storiesCollected} storiesMentioned={storiesMentioned} people={people}
-                            passID={this.clickHandler} />
+                        <RightBar view="Places" stories={storiesCollected} storiesMentioned={storiesMentioned} people={people} />
                     </div>
                 </div>
 
@@ -58,7 +40,6 @@ class PlaceView extends Component {
 }
 
 PlaceView.propTypes = {
-    "addID": PropTypes.func.isRequired,
     "place": PropTypes.shape({
         "fieldtrips": PropTypes.oneOfType([
             PropTypes.object,

--- a/src/reducers/tabViewerReducer.js
+++ b/src/reducers/tabViewerReducer.js
@@ -8,7 +8,7 @@ import {setSessionStorage} from "../data-stores/SessionStorageModel";
 /**
  * Switch to a new active tab
  * @param {Object} OldState The pre-switch state
- * @param {*} SwitchToIndex The tab index to switch to
+ * @param {Number} SwitchToIndex The tab index to switch to
  * @returns {Object} The state with the new active tab
  */
 function switchTab(OldState, SwitchToIndex) {
@@ -99,9 +99,8 @@ function addTab(ShallowNewState, {DisplayArtifactID, name, type}) {
                 // ...but set it to be inactive
                 "active": false,
             };
-        });
-        // add in the new, active view
-        updatedViews.push(newView);
+            // and add in the new view at the end
+        }).concat(newView);
         // if our window is smaller than 1100px (95% sure about the units)
         if (window.innerWidth <= 1100) {
             // if we have more than 5 tabs already (including home)
@@ -126,9 +125,9 @@ function addTab(ShallowNewState, {DisplayArtifactID, name, type}) {
 /**
  * Move a tab to a new index
  * Note that you cannot move a tab to index 0 (Home is fixed to index 0)
- * @param {*} OldState The pre-drag state of the tabs
- * @param {*} indices Object containing the tab index to move (OldTabIndex) and where to move it to (NewTabIndex)
- * @returns {*} The updated, tab-moved state
+ * @param {Object} OldState The pre-drag state of the tabs
+ * @param {Object} indices Object containing the tab index to move (OldTabIndex) and where to move it to (NewTabIndex)
+ * @returns {Object} The updated, tab-moved state
  */
 function moveTab(OldState, {OldTabIndex, NewTabIndex}) {
     // make sure we are not affecting the home tab
@@ -156,17 +155,24 @@ function moveTab(OldState, {OldTabIndex, NewTabIndex}) {
 }
 
 /**
- * Change the color of a tab
- * @param {*} OldState The pre-color change state
- * @param {*} payload Contains TabIndex, to indicate the tab to change, and Color, which is either a string/hexcode, or null to fall back to default active/inactive colors
- * @returns {Object} The color changed state
+ * Update a tab's attributes
+ * @param {Object} OldState The pre-update state
+ * @param {Object} payload Contains TabIndex, to indicate the tab to change, and updates that indicate what properties to set to what
+ * @returns {Object} The state with the updated tab
  */
-function changeTabColor(OldState, {TabIndex, Color}) {
+function updateTab(OldState, {TabIndex, updates}) {
     // get a new copy of the state to keep immutability
     let newState = {...OldState};
-    // set the specified tab's color
-    newState.views[TabIndex].color = Color;
-    // return the state with the changed tab
+    // get the view to update
+    let view = newState.views[TabIndex];
+    // update that view
+    newState.views[TabIndex] = {
+        // use the previous properties
+        ...view,
+        // but override any specified properties
+        ...updates,
+    };
+    // return the state with the updated tab
     return newState;
 }
 
@@ -196,9 +202,9 @@ export default function tabViewer(state = initialState.tabState, action) {
             console.log("MOVE_TAB ACTION", state);
             return moveTab(state, action.payload);
         // if we are to change a tab's color
-        case actions.CHANGE_TAB_COLOR:
-            console.log("CHANGE_TAB_COLOR ACTION", state);
-            return changeTabColor(state, action.payload);
+        case actions.UPDATE_TAB:
+            console.log("UPDATE_TAB ACTION", state);
+            return updateTab(state, action.payload);
         // unhandled action type
         default:
             // warn that we hit a bad action


### PR DESCRIPTION
Each book tab's page is no longer stored and changed inside of BookView but has been edited so that the tab's ID (and thus the page it renders) is changed whenever the page to show is changed. For some reason it doesn't save the currently viewed page if you are midway through a chapter on the actual text, only if you go to a new chapter/are looking at the annotation note things at the end of the chapter. I'm guessing it has something to do with how the .epub files are stored and that it counts the main content of a chapter as a single page.

Oh and I cleaned up other code a bit.