### PR TITLE
You can actually edit the timeline filters by typing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ node_modules/babel-preset-env/package.json
 
 # misc
 /.vscode
-.eslintrc.js
+.eslintrc.json
 .idea
 .DS_Store
 .env.local

--- a/src/components/Navigation/Navigation.js
+++ b/src/components/Navigation/Navigation.js
@@ -111,7 +111,7 @@ class Navigation extends Component {
         var idKey = ontologyToID[this.state.displayOntology];
         if (this.state.timeFilterOn) {
             // filter by time to get array with display artifacts that fit the time filter
-            var itemsWithinFieldtrips = dateFilterHelper(this.refs.fromDate.value, this.refs.toDate.value, this.state.displayOntology);
+            let itemsWithinFieldtrips = dateFilterHelper(this.state.fromDate, this.state.toDate, this.state.displayOntology);
             // if an item is in the itemsWithinFieldtrips, change what is displayed, NOT items list
             var displayList = [];
             // if it isn't a fieldtrip
@@ -155,65 +155,50 @@ class Navigation extends Component {
     }
 
     // sets time filters
-    timeFilterHandler() {
-        let fromDateForm = parseInt(this.refs.fromDate.value, 10);
-        let toDateForm = parseInt(this.refs.toDate.value, 10);
-        // check if the dates are valid dates (4 digits, between 1887 and 1899)
-        if (fromDateForm >= 1887 && toDateForm <= 1899) {
-            // check if time filter was switched
-            if (this.refs.TimeFilterOn.checked !== this.state.timeFilterOn) {
-                // if they are, then set this.state variables
+    timeFilterHandler(filter, event) {
+        switch (filter) {
+            case "fromDate":
                 this.setState({
-                    "timeFilterOn": !this.state.timeFilterOn,
-                    "fromDate": fromDateForm,
-                    "toDate": toDateForm,
-                }, () => {
-                    this.updateItems.bind(this)();
+                    "fromDate": event.target.value,
+                }, function() {
+                    // check if the dates are valid dates (4 digits, between 1887 and 1899)
+                    if (this.state.fromDate >= 1887) {
+                        this.updateItems();
+                    }
                 });
-            } else {
-                // just change from/to dates
+                break;
+            case "toDate":
                 this.setState({
-                    "fromDate": fromDateForm,
-                    "toDate": toDateForm,
-                }, () => {
-                    this.updateItems.bind(this)();
+                    "toDate": event.target.value,
+                }, function() {
+                    // check if the dates are valid dates (4 digits, between 1887 and 1899)
+                    if (this.state.toDate <= 1899) {
+                        this.updateItems();
+                    }
                 });
-            }
+                break;
+            case "timelineFilter":
+                this.setState({
+                    "timeFilterOn": event.target.checked,
+                }, function() {
+                    this.updateItems();
+                });
+                break;
+            default:
+                console.warn(`Invalid filter: ${filter}`);
         }
     }
 
     timeInputClickHandler(year) {
-        // display slider
-        if (year === "ToYear") {
-            // set this.state.toSelect = true
-            this.setState(() => {
-                return {"toSelect": true};
-            });
-        } else {
-            // set this.state.fromSelect = true
-            this.setState(() => {
-                return {"fromSelect": true};
-            });
-        }
+        this.setState({
+            [year === "ToYear" ? "toSelect" : "fromSelect"]: true,
+        });
     }
 
     timeInputEnd(year) {
-        // display slider
-        if (year === "toDate") {
-            // set this.state.toSelect = true
-            this.setState(() => {
-                return {"toSelect": false};
-            }, () => {
-                this.timeFilterHandler.bind(this);
-            });
-        } else {
-            // set this.state.fromSelect = true
-            this.setState(() => {
-                return {"fromSelect": false};
-            }, () => {
-                this.timeFilterHandler.bind(this);
-            });
-        }
+        this.setState({
+            [year === "toDate" ? "toSelect" : "fromSelect"]: false,
+        });
     }
 
     flipSearch(CurrentState) {
@@ -285,7 +270,7 @@ class Navigation extends Component {
                                     <div className="medium-2 medium-offset-1 cell">
                                         <div className="switch">
                                             <input className="switch-input" id="exampleSwitch" type="checkbox" checked={this.state.timeFilterOn}
-                                                name="exampleSwitch" onChange={this.timeFilterHandler.bind(this)} ref="TimeFilterOn" />
+                                                name="exampleSwitch" onChange={this.timeFilterHandler.bind(this, "timelineFilter")} />
                                             <label className="switch-paddle" htmlFor="exampleSwitch"><br />
                                                 <span style={{"fontSize": ".8em", "color": "black", "width": "150%"}}>Timeline</span>
                                                 <span className="show-for-sr">Enable Timeline</span>
@@ -294,38 +279,56 @@ class Navigation extends Component {
                                     </div>
                                     <div className="medium-2 cell text"><b>From</b></div>
                                     <div className="medium-2 cell">
-                                        <input className="year" type="text" name="FromYear" ref="fromDate"
+                                        <input
+                                            className="year"
+                                            type="number"
+                                            name="FromYear"
+                                            min={1887}
+                                            max={this.state.toDate}
                                             value={this.state.fromDate}
-                                            onChange={this.timeFilterHandler.bind(this)} onClick={(e) => {
+                                            onChange={this.timeFilterHandler.bind(this, "fromDate")}
+                                            onClick={(e) => {
                                                 e.preventDefault();
                                                 this.timeInputClickHandler.bind(this)("FromYear");
                                             }} />
-                                        <input className={`slider ${this.state.fromSelect ? "active" : ""}`}
-                                            type="range" min="1887" max={this.state.toDate} value={this.state.fromDate}
-                                            onChange={this.timeFilterHandler.bind(this)}
+                                        <input
+                                            className={`slider ${this.state.fromSelect ? "active" : ""}`}
+                                            type="range"
+                                            min="1887"
+                                            max={this.state.toDate}
+                                            value={this.state.fromDate}
+                                            onChange={this.timeFilterHandler.bind(this, "fromDate")}
                                             onMouseUp={(e) => {
                                                 e.preventDefault();
                                                 this.timeInputEnd.bind(this)("fromDate");
                                             }}
-                                            ref="fromDate"
                                             id="myRange" />
                                     </div>
                                     <div className="medium-1 cell text"><b>To</b></div>
                                     <div className="medium-2 cell">
-                                        <input className="year" type="text" name="ToYear" ref="toDate"
+                                        <input
+                                            className="year"
+                                            type="number"
+                                            name="ToYear"
+                                            min={this.state.fromDate}
+                                            max={1899}
                                             value={this.state.toDate}
-                                            onChange={this.timeFilterHandler.bind(this)} onClick={(e) => {
+                                            onChange={this.timeFilterHandler.bind(this, "toDate")}
+                                            onClick={(e) => {
                                                 e.preventDefault();
                                                 this.timeInputClickHandler.bind(this)("ToYear");
                                             }} />
-                                        <input className={`slider ${this.state.toSelect ? "active" : ""}`}
-                                            type="range" min={this.state.fromDate} max="1899" value={this.state.toDate}
-                                            onChange={this.timeFilterHandler.bind(this)}
+                                        <input
+                                            className={`slider ${this.state.toSelect ? "active" : ""}`}
+                                            type="range"
+                                            min={this.state.fromDate}
+                                            max="1899"
+                                            value={this.state.toDate}
+                                            onChange={this.timeFilterHandler.bind(this, "toDate")}
                                             onMouseUp={(e) => {
                                                 e.preventDefault();
                                                 this.timeInputEnd.bind(this)("toDate");
                                             }}
-                                            ref="toDate"
                                             id="myRange" />
                                     </div>
                                 </form>


### PR DESCRIPTION
Close #164

So, we were using the same ref twice for both filters which caused the draggable timelines to override the actual text inputs. Instead, I realized that each change event can be directly used to get the values, so no refs are needed there. Had to change a couple of other things to get it to work, but it should work out properly.