### PR TITLE
Clicking on story indices takes you to the appropriate part of Navigator

### DIFF
--- a/src/components/StoryView/StoryView.js
+++ b/src/components/StoryView/StoryView.js
@@ -2,7 +2,7 @@ import React, {Component} from "react";
 import Modal from "react-modal";
 import "react-sliding-pane/dist/react-sliding-pane.css";
 import RightBar from "../RightBar/RightBar";
-import {getPeopleByID} from "../../data-stores/DisplayArtifactModel";
+import {getPeopleByID, getGenreByID, getETKByID, getTangoByID} from "../../data-stores/DisplayArtifactModel";
 import {arrayTransformation} from "../../utils";
 import {addNode} from "../NexusGraph/NexusGraphModel";
 import "./StoryView.css";
@@ -12,6 +12,7 @@ import {bindActionCreators} from "redux";
 import * as searchActions from "../../actions/searchActions";
 import * as tabViewerActions from "../../actions/tabViewerActions";
 import connect from "react-redux/es/connect/connect";
+import {setSessionStorage} from "../../data-stores/SessionStorageModel";
 
 const indexToVersion = {
     "0": "english_manuscript",
@@ -205,6 +206,7 @@ class StoryView extends Component {
         const {story} = this.props,
             {
                 annotation,
+                etk_index,
                 "etk_index": {
                     heading_english,
                 },
@@ -332,15 +334,49 @@ class StoryView extends Component {
                                 {/* only show indices if that is the open accordion tab */}
                                 {openTab === 1 &&
                                     <div className="body">
-                                        <b>Genre</b> <button className="button keyword-well">{genre.name}</button><br />
-                                        <b>ETK Index</b> <button className="button keyword-well">{heading_english}</button><br />
+                                        <b>Genre</b>
+                                        <button
+                                            className="button keyword-well"
+                                            onClick={() => {
+                                                setSessionStorage("SelectedNavOntology", {
+                                                    "data": "Genres",
+                                                });
+                                                setSessionStorage("dropdownLists", [getGenreByID(genre.id)]);
+                                                this.props.actions.switchTabs(0);
+                                            }}>
+                                            {genre.name}
+                                        </button>
+                                        <br />
+                                        <b>ETK Index</b>
+                                        <button
+                                            className="button keyword-well"
+                                            onClick={() => {
+                                                setSessionStorage("SelectedNavOntology", {
+                                                    "data": "ETK Index",
+                                                });
+                                                setSessionStorage("dropdownLists", [getETKByID(etk_index.id)]);
+                                                console.log(etk_index, getETKByID(etk_index.id));
+                                                this.props.actions.switchTabs(0);
+                                            }}>
+                                            {heading_english}
+                                        </button>
+                                        <br />
                                         <b>Tangherlini Indices</b><br />
                                         {/* render the indices by their display names */}
-                                        {arrayTransformation(tango_indices.tango_index).map(({display_name}, i) => (
-                                            <div className="button keyword-well" key={i}>
-                                                {display_name}
-                                            </div>
-                                        ))}
+                                        {arrayTransformation(tango_indices.tango_index).map((tango, i) => {
+                                            return (
+                                                <button className="button keyword-well" key={i}
+                                                    onClick={() => {
+                                                        setSessionStorage("SelectedNavOntology", {
+                                                            "data": "Tangherlini Index",
+                                                        });
+                                                        setSessionStorage("dropdownLists", [getTangoByID(tango.id).type, getTangoByID(tango.id)]);
+                                                        this.props.actions.switchTabs(0);
+                                                    }}>
+                                                    {tango.display_name}
+                                                </button>
+                                            );
+                                        })}
                                     </div>}
                             </li>
                             <li className={`accordion-item ${openTab === 2 && "is-active"}`}>

--- a/src/data-stores/DisplayArtifactModel.js
+++ b/src/data-stores/DisplayArtifactModel.js
@@ -266,9 +266,9 @@ export const tangoTypes = {
         "children": getChildren("Animals", true),
         "level": 3,
     },
-    "Action or events": {
-        "name": "Action or events",
-        "children": getChildren("Action or events", true),
+    "Actions or events": {
+        "name": "Actions or events",
+        "children": getChildren("Actions or events", true),
         "level": 3,
     },
     "Time, Season, Weather": {
@@ -589,4 +589,49 @@ export function getManuscriptURI(story_id){
     }
     console.warn("No images!");
     return [];
+}
+
+/**
+ * Retrieve a genre by its ID
+ * @param {Number} genre_id The ID of the genre to get
+ * @returns {Object} The genre object
+ */
+export function getGenreByID(genre_id) {
+    const genre = dataGenre.genre.find((matchingGenre) => matchingGenre.id === genre_id);
+    if (genre) {
+        return genre;
+    } else {
+        console.warn("Invalid genre ID");
+        return null;
+    }
+}
+
+/**
+ * Retrieve an ETK index by its ID
+ * @param {Number} etk_id The ID of the ETK index to get
+ * @returns {Object} The ETK object
+ */
+export function getETKByID(etk_id) {
+    const etk = dataETK.etk_index.find((matchingETK) => matchingETK.id === etk_id);
+    if (etk) {
+        return etk;
+    } else {
+        console.warn("Invalid ETK ID");
+        return null;
+    }
+}
+
+/**
+ * Retrieve a Tango index by its ID
+ * @param {Number} tango_id The ID of the Tango index to get
+ * @returns {Object} The Tango object
+ */
+export function getTangoByID(tango_id) {
+    const tango = data.tango.find((matchingTango) => matchingTango.id === tango_id);
+    if (tango) {
+        return tango;
+    } else {
+        console.warn("Invalid Tango ID");
+        return null;
+    }
 }


### PR DESCRIPTION
Close #158

Clicking on ETK Indices, Tango Indices, and Genres takes you to the appropriate category and dropdown in Navigator. Added some extra functions to retrieve Tango/ETK Indices and genres by ID, since Story objects do not contain the full object. Also fixed a type in the tango object preventing one category from being rendered.